### PR TITLE
Fix stubs

### DIFF
--- a/muse_test.go
+++ b/muse_test.go
@@ -46,16 +46,20 @@ func (p *memPersist) Load(data *shard.PersistData) error {
 
 type stubWallet struct{}
 
-func (stubWallet) NewWalletAddress() (uh types.UnlockHash, err error)                       { return }
-func (stubWallet) SignTransaction(*types.Transaction, []crypto.Hash) (err error)            { return }
-func (stubWallet) UnspentOutputs(bool) (us []modules.UnspentOutput, err error)              { return }
-func (stubWallet) UnconfirmedParents(types.Transaction) (ps []types.Transaction, err error) { return }
-func (stubWallet) UnlockConditions(types.UnlockHash) (uc types.UnlockConditions, err error) { return }
+func (stubWallet) Address() (_ types.UnlockHash, _ error) { return }
+func (stubWallet) FundTransaction(*types.Transaction, types.Currency) ([]crypto.Hash, func(), error) {
+	return nil, func() {}, nil
+}
+func (stubWallet) SignTransaction(txn *types.Transaction, toSign []crypto.Hash) error {
+	txn.TransactionSignatures = append(txn.TransactionSignatures, make([]types.TransactionSignature, len(toSign))...)
+	return nil
+}
 
 type stubTpool struct{}
 
-func (stubTpool) AcceptTransactionSet([]types.Transaction) (err error) { return }
-func (stubTpool) FeeEstimate() (min, max types.Currency, err error)    { return }
+func (stubTpool) AcceptTransactionSet([]types.Transaction) (_ error)                    { return }
+func (stubTpool) UnconfirmedParents(types.Transaction) (_ []types.Transaction, _ error) { return }
+func (stubTpool) FeeEstimate() (_, _ types.Currency, _ error)                           { return }
 
 func startSHARD(hpk hostdb.HostPublicKey, ann []byte) (string, func() error) {
 	l, err := net.Listen("tcp", ":0")


### PR DESCRIPTION
I got this error on v0.6.2. 

```
11:44:06 ❯ go test ./... -race
# lukechampine.com/muse [lukechampine.com/muse.test]
./muse_test.go:93:39: cannot use stubWallet literal (type stubWallet) as type proto.Wallet in argument to NewServer:
        stubWallet does not implement proto.Wallet (missing Address method)
./muse_test.go:93:52: cannot use stubTpool literal (type stubTpool) as type proto.TransactionPool in argument to NewServer:
        stubTpool does not implement proto.TransactionPool (missing UnconfirmedParents method)
FAIL    lukechampine.com/muse [build failed]
?       lukechampine.com/muse/cmd/muse  [no test files]
?       lukechampine.com/muse/cmd/musec [no test files]
FAIL
```

This PR copy-and-pastes `stubWallet` and `stubTpool` from `us` to fix the above error.