### PR TITLE
Replace golang.org/x/crypto/ssh/terminal with golang.org/x/term

### DIFF
--- a/cmd/muse/main.go
+++ b/cmd/muse/main.go
@@ -15,7 +15,7 @@ import (
 	"gitlab.com/NebulousLabs/Sia/modules/consensus"
 	"gitlab.com/NebulousLabs/Sia/modules/gateway"
 	"gitlab.com/NebulousLabs/Sia/modules/transactionpool"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	"lukechampine.com/muse"
 	"lukechampine.com/shard"
 	"lukechampine.com/us/wallet"
@@ -34,7 +34,7 @@ func getSeed() wallet.Seed {
 		fmt.Println("Using WALRUS_SEED environment variable")
 	} else {
 		fmt.Print("Seed: ")
-		pw, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		pw, err := term.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			log.Fatal("Could not read seed phrase:", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	gitlab.com/NebulousLabs/Sia v1.5.4
 	gitlab.com/NebulousLabs/encoding v0.0.0-20200604091946-456c3dc907fe
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 	lukechampine.com/flagg v1.1.1
 	lukechampine.com/frand v1.3.0
 	lukechampine.com/shard v0.3.5


### PR DESCRIPTION
golangci-lint shows this warning

```
cmd/muse/main.go:18:2: SA1019: package golang.org/x/crypto/ssh/terminal is deprecated: this package moved to golang.org/x/term. (staticcheck)
        "golang.org/x/crypto/ssh/terminal"
        ^
```

This PR fixes the above warning.